### PR TITLE
Added include to fix undefined __cdecl on GCC

### DIFF
--- a/SysInfo/Crash.h
+++ b/SysInfo/Crash.h
@@ -4,6 +4,7 @@
 #define _CrashHandler_Crash_h_
 
 #include <Core/Core.h>
+#include "SysInfo_in.h"
 
 namespace Upp {
 


### PR DESCRIPTION
On GCC compilation of Crash.cpp complains about __cdecl being undefined.
With the include it just warns about ignored 'cdecl' attribute (which, imho, is useless here).